### PR TITLE
Update Trivy scan task to use "--db-repository" flag

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -22,3 +22,4 @@ version: 0.0.3
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.0.0"
+

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -22,4 +22,3 @@ version: 0.0.3
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.0.0"
-

--- a/helm/templates/task.yaml
+++ b/helm/templates/task.yaml
@@ -29,8 +29,7 @@ spec:
               optional: true
       script: |
         if [ $(params.IMAGE_REGISTRY) != "NA" ]; then
-          trivy image $(params.IMAGE_REGISTRY)/$(params.IMAGE_NAME)
+          trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 $(params.IMAGE_REGISTRY)/$(params.IMAGE_NAME)
         else
           trivy image ${IMAGE_REGISTRY}/$(params.IMAGE_NAME)
         fi        
-

--- a/helm/templates/task.yaml
+++ b/helm/templates/task.yaml
@@ -33,3 +33,4 @@ spec:
         else
           trivy image ${IMAGE_REGISTRY}/$(params.IMAGE_NAME)
         fi        
+

--- a/task/stakater-trivy-scan/stakater-trivy-scan.yaml
+++ b/task/stakater-trivy-scan/stakater-trivy-scan.yaml
@@ -5,7 +5,7 @@ kind: Task
 metadata:
   name: stakater-trivy-scan
   labels:
-    app.kubernetes.io/version: "0.0.7"
+    app.kubernetes.io/version: "0.0.5"
 spec:
   params:
     - name: IMAGE_NAME
@@ -31,7 +31,7 @@ spec:
               optional: true
       script: |
         if [ $(params.IMAGE_REGISTRY) != "NA" ]; then
-          trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 $(params.IMAGE_REGISTRY)/$(params.IMAGE_NAME)
+          trivy image $(params.IMAGE_REGISTRY)/$(params.IMAGE_NAME)
         else
-          trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 ${IMAGE_REGISTRY}/$(params.IMAGE_NAME)
+          trivy image ${IMAGE_REGISTRY}/$(params.IMAGE_NAME)
         fi


### PR DESCRIPTION
Trivy image command (by default) uses ghcr repo to pull database for vulnerability details. Problem with ghcr is that there is a rate limiting policy applied that reject almost 50% of the requests with HTTP 429. 
As a solution mentioned [here](https://github.com/aquasecurity/trivy/discussions/7538#discussioncomment-10741936).
This PR has changes to use AWS registry to fetch db. 