### PR TITLE
Update to use correct token

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,4 +17,4 @@ jobs:
       CONTAINER_REGISTRY_URL: ghcr.io/stakater
       CONTAINER_REGISTRY_USERNAME: ${{ secrets.GHCR_USERNAME }}
       CONTAINER_REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}


### PR DESCRIPTION
use PUBLISH_TOKEN instead of GITHUB_TOKEN
GITHUB_TOKEN does not exist anymore