### PR TITLE
Update else condition for stakater-trivy-scan

### DIFF
--- a/helm/templates/task.yaml
+++ b/helm/templates/task.yaml
@@ -31,5 +31,5 @@ spec:
         if [ $(params.IMAGE_REGISTRY) != "NA" ]; then
           trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 $(params.IMAGE_REGISTRY)/$(params.IMAGE_NAME)
         else
-          trivy image ${IMAGE_REGISTRY}/$(params.IMAGE_NAME)
+          trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 ${IMAGE_REGISTRY}/$(params.IMAGE_NAME)
         fi        


### PR DESCRIPTION
There was a missing --db-repository flag in else condition for stakater-trivy-scan. Because of which it was still getting pointed to ghcr ones. Made change for that